### PR TITLE
Switch to Ubuntu 24.04 for fixing CI build

### DIFF
--- a/.github/workflows/turnip_builder.yml
+++ b/.github/workflows/turnip_builder.yml
@@ -7,18 +7,15 @@ on:
 
 jobs:
   start_building_turnip:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 
     - name: Prepare environment
       run: |
-        sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+        sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
         sudo apt update
         sudo apt build-dep mesa -y
-        sudo sed -i 's/jammy/mantic/g' /etc/apt/sources.list
-        sudo apt update
-        sudo apt install meson
 
     - name: Execute build script
       run: bash ./turnip_builder.sh


### PR DESCRIPTION
It turns out that build fails now when trying to use mantic repo https://github.com/ilhan-athn7/freedreno_turnip-CI/actions/runs/12102698916 