### PR TITLE
ci/android: fix meson C++ cross-compiler argument detection and disable EGL

### DIFF
--- a/turnip_builder.sh
+++ b/turnip_builder.sh
@@ -121,7 +121,7 @@ EOF
 			-Dvulkan-beta=true \
 			-Dfreedreno-kmds=kgsl \
 			-Db_lto=true \
-			-Dstrip=true
+			-Dstrip=true \
 			-Degl=disabled &> "$workdir/meson_log"
 
 	echo "Compiling build files ..." $'\n'

--- a/turnip_builder.sh
+++ b/turnip_builder.sh
@@ -82,7 +82,7 @@ build_lib_for_android(){
 [binaries]
 ar = '$ndk/llvm-ar'
 c = ['ccache', '$ndk/aarch64-linux-android$sdkver-clang']
-cpp = ['ccache', '$ndk/aarch64-linux-android$sdkver-clang++', '-fno-exceptions', '-fno-unwind-tables', '-fno-asynchronous-unwind-tables', '-static-libstdc++', '-Wno-error=c++11-narrowing']
+cpp = ['ccache', '$ndk/aarch64-linux-android$sdkver-clang++', '-fno-exceptions', '-fno-unwind-tables', '-fno-asynchronous-unwind-tables', '--start-no-unused-arguments', '-static-libstdc++', '--end-no-unused-arguments']
 c_ld = '$ndk/ld.lld'
 cpp_ld = '$ndk/ld.lld'
 strip = '$ndk/aarch64-linux-android-strip'
@@ -121,7 +121,8 @@ EOF
 			-Dvulkan-beta=true \
 			-Dfreedreno-kmds=kgsl \
 			-Db_lto=true \
-			-Dstrip=true &> "$workdir/meson_log"
+			-Dstrip=true
+			-Degl=disabled &> "$workdir/meson_log"
 
 	echo "Compiling build files ..." $'\n'
 		ninja -C build-android-aarch64 &> "$workdir/ninja_log"


### PR DESCRIPTION
commit !33013 - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/33013/diffs#diff-content-a633767b0286f225f5204ce895faf24f5d3f5611

Devs also made some changes to egl and it is causing compilation errors, but we dont need this, so disabled.

credits:

Danylo
Weab-chan
JeezDisReez