### PR TITLE
meson: Fix glslangValidator not found during turnip build

### DIFF
--- a/turnip_builder.sh
+++ b/turnip_builder.sh
@@ -4,7 +4,7 @@
 green='\033[0;32m'
 red='\033[0;31m'
 nocolor='\033[0m'
-deps="meson ninja patchelf unzip curl pip flex bison zip"
+deps="meson ninja patchelf unzip curl pip flex bison zip glslang glslangValidator"
 workdir="$(pwd)/turnip_workdir"
 magiskdir="$workdir/turnip_module"
 ndkver="android-ndk-r28b"


### PR DESCRIPTION
When building Mesa 25.1.1 with Vulkan drivers (e.g., Turnip), Meson fails if `glslangValidator` is not found, causing the following error:

    meson.build:634:15: ERROR: Program 'glslangValidator' not found or not executable

This tool is provided by the `glslang-tools` package on most distributions, and also includes the necessary SPIR-V utilities for shader compilation and validation.

This patch updates the build documentation and ensures that the validator is expected in the native build environment. Builders must install `glslang-tools` and ensure it's available in the `PATH` prior to running Meson.

To resolve the issue on Ubuntu/Debian systems:

```sh
sudo apt install glslang-tools
```
Signed-off-by: Shankar Vallabhan <shankarmanu@protonmail.com>