### PR TITLE
Switch from full LTO to ThinLTO

### DIFF
--- a/turnip_builder.sh
+++ b/turnip_builder.sh
@@ -121,6 +121,7 @@ EOF
 			-Dvulkan-beta=true \
 			-Dfreedreno-kmds=kgsl \
 			-Db_lto=true \
+   			-Db_lto_mode=thin \
 			-Dstrip=true \
 			-Degl=disabled &> "$workdir/meson_log"
 


### PR DESCRIPTION
Full LTO increases build times without noticeable runtime benefits for Turnip.

Switching to ThinLTO reduces compile time while retaining most optimization benefits.

On an i7-4770 with 16 GB RAM , this change reduces build time by 10-12 seconds.

Tested on A618, A619, A640, and A650 with no performance regressions.