### PR TITLE
Fix : customize.sh  -  update set_perm rules

### DIFF
--- a/turnip_builder.sh
+++ b/turnip_builder.sh
@@ -175,9 +175,8 @@ description=Turnip is an open-source vulkan driver for devices with adreno GPUs.
 EOF
 
 		cat <<EOF >"customize.sh"
-set_perm_recursive \$MODPATH/system 0 0 755 u:object_r:system_file:s0
-set_perm_recursive \$MODPATH/system/vendor 0 2000 755 u:object_r:vendor_file:s0
-set_perm \$MODPATH/$p1/vulkan.adreno.so 0 0 0644 u:object_r:same_process_hal_file:s0
+set_perm_recursive $MODPATH/system 0 0 0755 0644
+set_perm $MODPATH/system/vendor/lib64/hw/vulkan.adreno.so 0 0 0644
 EOF
 
 	echo "Copy necessary files from work directory ..." $'\n'


### PR DESCRIPTION
Magisk v30 and above no longer properly apply custom SELinux contexts via `set_perm` in customize.sh. This caused `vulkan.adreno.so` to fail initialization at runtime.

Switched to the new required syntax:
- `set_perm_recursive $MODPATH/system 0 0 0755 0644`
- `set_perm $MODPATH/system/vendor/lib64/hw/vulkan.adreno.so 0 0 0644`

With this change, the Turnip Vulkan driver loads correctly on Magisk v30+ and also works fine on KernelSU and KernelSU-Next.

<br> <br>

![462771736-bed50756-7f39-49d0-9bb0-68191facfebb](https://github.com/user-attachments/assets/a385b764-cd26-4f9d-8c41-307bb8e951fb)


<img width="1080" height="2400" alt="Screenshot_20250822-144632_KernelSU Next" src="https://github.com/user-attachments/assets/68c7c44a-d93a-413e-9903-4b04cb9171c6" />

<img width="1080" height="2400" alt="Screenshot_20250822-144640_GLview" src="https://github.com/user-attachments/assets/a76a2700-19ae-41d3-93ef-2ff229dd4189" />

<img width="1080" height="2400" alt="Screenshot_20250822-144644_KernelSU Next" src="https://github.com/user-attachments/assets/6dd5e571-182b-4f37-9d39-d5294b87412a" />